### PR TITLE
Fix extra empty path issue with HttpUrl.init?(url:)

### DIFF
--- a/Sources/SwiftHttp/HttpUrl.swift
+++ b/Sources/SwiftHttp/HttpUrl.swift
@@ -237,20 +237,19 @@ extension HttpUrl {
     ///
     /// Returns `nil` if a `HttpUrl` cannot be formed with the `URL` (for example, if the string contains characters that are illegal in a URL, or is an empty string).
     public init?(url: URL) {
-        guard
-            let components = URLComponents(
-                url: url,
-                resolvingAgainstBaseURL: true
-            )
-        else { return nil }
-        var path = components.path.trimmingCharacters(
-            in: CharacterSet(charactersIn: "/")
-        ).components(separatedBy: "/")
+        guard let components = URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: true
+        ) else { return nil }
+        
+        var path = components.path
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .components(separatedBy: "/")
+            .filter { !$0.isEmpty }
         let resource: String?
         if path.last?.contains(".") == true {
             resource = path.removeLast()
-        }
-        else {
+        } else {
             resource = nil
         }
         self.init(

--- a/Tests/SwiftHttpTests/HttpUrlTests.swift
+++ b/Tests/SwiftHttpTests/HttpUrlTests.swift
@@ -78,4 +78,10 @@ final class HttpUrlTests: XCTestCase {
             "https://jsonplaceholder.typicode.com/todos?foo=bar"
         )
     }
+    
+    func testURLInitPathIssue() throws {
+        let url = URL(string: "https://jsonplaceholder.typicode.com")!
+        let baseUrl = try XCTUnwrap(HttpUrl(url: url))
+        XCTAssertEqual(baseUrl.path, [])
+    }
 }


### PR DESCRIPTION
When using swift-http in my package, I found this unexpected behavior.

```
let baseURL = URL(string: "https://forums.swift.org")!
let httpURL = HttpUrl(url: baseURL)!
let newHttpURL = httpURL.path("site.json")
print(newHttpURL.path)

## Unexpected result
https://forums.swift.org//site.json
## Expected result
https://forums.swift.org/site.json
```