### PR TITLE
Fix ambiguous URLSessionHttpClient()

### DIFF
--- a/Sources/SwiftHttp/UrlSessionHttpClient.swift
+++ b/Sources/SwiftHttp/UrlSessionHttpClient.swift
@@ -47,6 +47,7 @@ public struct UrlSessionHttpClient: HttpClient {
     ///
     /// - Returns: An instance of `HTTPClient`.
     ///
+    @_disfavoredOverload
     @available(*, deprecated, message: "Use init(session:logLevel:) instead.")
     public init(session: URLSession = .shared, log: Bool = false) {
         var logger = Logger(label: loggerLabel)


### PR DESCRIPTION
## Summary:
Resolves ambiguity in URLSessionHttpClient.init() that was causing build and CI failures.

## Details:
- URLSessionHttpClient.init() was found to be ambiguous, which resulted in numerous code and Continuous Integration (CI) breakages.
- As there was no option to create an issue, I am directly submitting this MR.

## Changes:
add @_disfavoredOverload attribute to old init declaration
## 
Impact:
- This fix resolves the ambiguity, and the codebase and CI are now stable.

## Note:
- It is recommended to enable issue creation for this repository to ensure that problems can be documented before submitting fixes.

